### PR TITLE
Adding Fts, closing issue #2:

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,34 @@
 FROM sameersbn/ubuntu:14.04.20150825
 
-ENV TOR_BROWSER_VERSION=4.5.3 \
-    WEB_BROWSER_USER=browser
+ENV TOR_VERSION=5.0.3 \
+	TOR_FINGERPRINT=0x4E2C6E8793298290
 
 RUN wget -q -O - "https://dl-ssl.google.com/linux/linux_signing_key.pub" | sudo apt-key add - \
  && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
  && apt-get update \
- && apt-get install -y xz-utils file locales dbus-x11 pulseaudio dmz-cursor-theme \
+ && apt-get install -y xz-utils file locales dbus-x11 pulseaudio dmz-cursor-theme curl \
       fonts-dejavu fonts-liberation hicolor-icon-theme \
       libcanberra-gtk3-0 libcanberra-gtk-module libcanberra-gtk3-module \
       libasound2 libglib2.0 libgtk2.0-0 libdbus-glib-1-2 libxt6 libexif12 \
-      libgl1-mesa-glx libgl1-mesa-dri \
+      libgl1-mesa-glx libgl1-mesa-dri libstdc++6 nvidia-346 \
       google-chrome-stable chromium-browser firefox \
  && update-locale LANG=C.UTF-8 LC_MESSAGES=POSIX \
  && mkdir -p /usr/lib/tor-browser \
- && wget -O /tmp/tor-browser-linux64-${TOR_BROWSER_VERSION}_en-US.tar.xz \
-      https://www.torproject.org/dist/torbrowser/${TOR_BROWSER_VERSION}/tor-browser-linux64-${TOR_BROWSER_VERSION}_en-US.tar.xz \
- && tar -Jvxf /tmp/tor-browser-linux64-${TOR_BROWSER_VERSION}_en-US.tar.xz --strip=1 -C /usr/lib/tor-browser \
+ && wget -O /tmp/tor-browser-linux64-${TOR_VERSION}_en-US.tar.xz  https://www.torproject.org/dist/torbrowser/${TOR_VERSION}/tor-browser-linux64-${TOR_VERSION}_en-US.tar.xz \
+ && wget -O /tmp/tor-browser-linux64-${TOR_VERSION}_en-US.tar.xz.asc https://www.torproject.org/dist/torbrowser/${TOR_VERSION}/tor-browser-linux64-${TOR_VERSION}_en-US.tar.xz.asc \
+ && mkdir ~/.gnupg \
+ && gpg --keyserver hkp://hkps.pool.sks-keyservers.net:80 --recv-keys ${TOR_FINGERPRINT} \
+ && gpg --fingerprint ${TOR_FINGERPRINT} | grep "Key fingerprint = EF6E 286D DA85 EA2A 4BA7  DE68 4E2C 6E87 9329 8290" \
+ && gpg /tmp/tor-browser-linux64-${TOR_VERSION}_en-US.tar.xz.asc \
+ && tar -Jvxf /tmp/tor-browser-linux64-${TOR_VERSION}_en-US.tar.xz --strip=1 -C /usr/lib/tor-browser \
  && ln -sf /usr/lib/tor-browser/Browser/start-tor-browser /usr/bin/tor-browser \
- && rm -rf /tmp/tor-browser-linux64-${TOR_BROWSER_VERSION}_en-US.tar.xz \
+ && rm -rf /tmp/tor-browser-linux64-${TOR_VERSION}_en-US.tar.xz \
+ && rm -rf ~/.gnupg \
  && rm -rf /var/lib/apt/lists/*
 
 COPY scripts/ /var/cache/browser-box/
 COPY entrypoint.sh /sbin/entrypoint.sh
+COPY confs/local.conf /etc/fonts/local.conf
 RUN chmod 755 /sbin/entrypoint.sh
 
 ENTRYPOINT ["/sbin/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ VOLUMES = \
 	--volume=/run/user/$(shell id -u)/pulse:/run/pulse
 
 ENV_INSTL_USER = \
-	--env="BROWSER_BOX_USER=${USER}"
+	--env="BROWSER_BOX_USER=${USER}" \
+	--env="BROWSER_BOX_REPO=${USER}"
 
 ifdef CHROME_USERDATA
 ENV_CHROME_USERDATA = \

--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ docker run -it --rm \
   sameersbn/browser-box:latest install
 ```
 
+If you would the settings for chrome and firfox to persist
+afer each time the browser is launched then you will need to add additional environment variable to the install command. In the example below "username" needs to get replace with your loggin user name.
+
+```bash
+docker run -it --rm \
+  --volume /usr/local/bin:/target \
+  --env CHROME_USERDATA=/home/username/.chrome
+  --env FIREFOX_USERDATA=/home/username/.mozillia
+  sameersbn/browser-box:latest install
+```
+
+
 This will install wrapper scripts to launch:
 
 - `chromium-browser`

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ With the image locally available, install the wrapper scripts using:
 ```bash
 docker run -it --rm \
   --volume /usr/local/bin:/target \
+  --env BROWSER_BOX_REPO=sameersbn \
   sameersbn/browser-box:latest install
 ```
 
@@ -78,8 +79,9 @@ afer each time the browser is launched then you will need to add additional envi
 ```bash
 docker run -it --rm \
   --volume /usr/local/bin:/target \
-  --env CHROME_USERDATA=/home/username/.chrome
-  --env FIREFOX_USERDATA=/home/username/.mozillia
+  --env CHROME_USERDATA=/home/username/.chrome \
+  --env FIREFOX_USERDATA=/home/username/.mozillia \
+  --env BROWSER_BOX_REPO=sameersbn \
   sameersbn/browser-box:latest install
 ```
 

--- a/confs/local.conf
+++ b/confs/local.conf
@@ -1,0 +1,29 @@
+<?xml version='1.0'?>
+<!DOCTYPE fontconfig SYSTEM 'fonts.dtd'>
+<fontconfig>
+<match target="font">
+<edit mode="assign" name="rgba">
+<const>rgb</const>
+</edit>
+</match>
+<match target="font">
+<edit mode="assign" name="hinting">
+<bool>true</bool>
+</edit>
+</match>
+<match target="font">
+<edit mode="assign" name="hintstyle">
+<const>hintslight</const>
+</edit>
+</match>
+<match target="font">
+<edit mode="assign" name="antialias">
+<bool>true</bool>
+</edit>
+</match>
+<match target="font">
+<edit mode="assign" name="lcdfilter">
+<const>lcddefault</const>
+</edit>
+</match>
+</fontconfig>

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,7 @@ set -e
 
 USER_UID=${USER_UID:-1000}
 USER_GID=${USER_GID:-1000}
+BROWSER_BOX_USER=${BROWSER_BOX_USER:-browser}
 
 install_browser_box() {
   echo "Installing browser-box..."
@@ -17,6 +18,21 @@ install_browser_box() {
   ln -sf browser-box /target/chromium-browser
   echo "Installing firefox..."
   ln -sf browser-box /target/firefox
+  echo "Installing url luancher..."
+  ln -sf browser-box /target/browser-exec
+  if [ "${BROWSER_BOX_USER}" != "browser" ] && [ -n "${BROWSER_BOX_USER}" ]; then
+    echo "Updating user to ${BROWSER_BOX_USER}..."
+    sed -i -e s%"BROWSER_BOX_USER:-browser"%"BROWSER_BOX_USER:-${BROWSER_BOX_USER}"%1 /target/browser-box
+  fi
+  if [[ -n "${CHROME_USERDATA}" ]]; then
+    echo "Updating Chrome user volume..."
+    sed -i -e s%"CHROME_USERDATA=.*$"%"CHROME_USERDATA\=${CHROME_USERDATA}"%1 /target/browser-box
+  fi
+  if [[ -n "${FIREFOX_USERDATA}" ]]; then
+    echo "Updating FireFox user volume..."
+    sed -i -e s%"FIREFOX_USERDATA=.*$"%"FIREFOX_USERDATA\=${FIREFOX_USERDATA}"%1 /target/browser-box
+  fi
+
 }
 
 uninstall_browser_box() {
@@ -32,18 +48,33 @@ uninstall_browser_box() {
   rm -rf /target/chromium-browser
   echo "Uninstalling firefox..."
   rm -rf /target/firefox
+  echo "Uninstalling url launcher..."
+  rm -rf /target/browser-exec
 }
 
 create_user() {
+  # ensure home directory is owned by browser
+  # and that profile files exist
+  if [[ -d /home/${BROWSER_BOX_USER} ]]; then
+    chown ${USER_UID}:${USER_GID} /home/${BROWSER_BOX_USER}
+    # copy user files from /etc/skel
+    cp /etc/skel/.bashrc /home/${BROWSER_BOX_USER}
+    cp /etc/skel/.bash_logout /home/${BROWSER_BOX_USER}
+    cp /etc/skel/.profile /home/${BROWSER_BOX_USER}
+    chown ${USER_UID}:${USER_GID} \
+		/home/${BROWSER_BOX_USER}/.bashrc \
+		/home/${BROWSER_BOX_USER}/.profile \
+		/home/${BROWSER_BOX_USER}/.bash_logout
+  fi
   # create group with USER_GID
-  if ! getent group ${WEB_BROWSER_USER} >/dev/null; then
-    groupadd -f -g ${USER_GID} ${WEB_BROWSER_USER}
+  if ! getent group ${BROWSER_BOX_USER} >/dev/null; then
+    groupadd -f -g ${USER_GID} ${BROWSER_BOX_USER} 2> /dev/null
   fi
 
   # create user with USER_UID
-  if ! getent passwd ${WEB_BROWSER_USER} >/dev/null; then
+  if ! getent passwd ${BROWSER_BOX_USER} >/dev/null; then
     adduser --disabled-login --uid ${USER_UID} --gid ${USER_GID} \
-      --gecos 'Browser Box' ${WEB_BROWSER_USER}
+      --gecos 'Browser Box' ${BROWSER_BOX_USER}
   fi
 }
 
@@ -57,13 +88,13 @@ grant_access_to_video_devices() {
   done
 
   if [[ -n $VIDEO_GID ]]; then
-    usermod -a -G $VIDEO_GID ${WEB_BROWSER_USER}
+    usermod -a -G $VIDEO_GID ${BROWSER_BOX_USER}
   fi
 }
 
 launch_browser() {
-  cd /home/${WEB_BROWSER_USER}
-  exec sudo -u ${WEB_BROWSER_USER} -H PULSE_SERVER=/run/pulse/native $@ ${extra_opts}
+  cd /home/${BROWSER_BOX_USER}
+  exec sudo -u ${BROWSER_BOX_USER} -H LD_PRELOAD='/usr/$LIB/libstdc++.so.6' PULSE_SERVER=/run/pulse/native $@ ${extra_opts}
 }
 
 case "$1" in

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,9 @@ set -e
 
 USER_UID=${USER_UID:-1000}
 USER_GID=${USER_GID:-1000}
+
 BROWSER_BOX_USER=${BROWSER_BOX_USER:-browser}
+BROWSER_BOX_REPO=${BROWSER_BOX_REPO:-sameersbn}
 
 install_browser_box() {
   echo "Installing browser-box..."
@@ -32,6 +34,7 @@ install_browser_box() {
     echo "Updating FireFox user volume..."
     sed -i -e s%"FIREFOX_USERDATA=.*$"%"FIREFOX_USERDATA\=${FIREFOX_USERDATA}"%1 /target/browser-box
   fi
+  sed -i -e s%"\(BROWSER_BOX_REPO=\).*$"%"\1${BROWSER_BOX_REPO}"%g
 
 }
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,7 +34,7 @@ install_browser_box() {
     echo "Updating FireFox user volume..."
     sed -i -e s%"FIREFOX_USERDATA=.*$"%"FIREFOX_USERDATA\=${FIREFOX_USERDATA}"%1 /target/browser-box
   fi
-  sed -i -e s%"\(BROWSER_BOX_REPO=\).*$"%"\1${BROWSER_BOX_REPO}"%g
+  sed -i -e s%"\(BROWSER_BOX_REPO=\).*$"%"\1${BROWSER_BOX_REPO}"%1 /target/browser-box
 
 }
 

--- a/scripts/browser-box
+++ b/scripts/browser-box
@@ -56,8 +56,13 @@ prepare_docker_env_parameters() {
   ENV_VARS+=" --env=USER_GID=${USER_GID}"
   ENV_VARS+=" --env=DISPLAY"
   ENV_VARS+=" --env=XAUTHORITY=${XAUTH}"
-  ENV_VARS+=" --env=TZ=$(cat /etc/timezone)"
   ENV_VARS+=" --env=BROWSER_BOX_USER=${BROWSER_BOX_USER}"
+  if [ -f /etc/timezone ]; then
+	  ENV_VARS+=" --env=TZ=$(cat /etc/timezone)"
+  else
+    [ ! -z "${TIMEZONE}" ] && ENV_VARS+=" --env=TZ=${TIMEZONE}"
+  fi
+
 }
 
 prepare_docker_volume_parameters() {
@@ -72,8 +77,8 @@ prepare_docker_volume_parameters() {
 # TODO: Need to add tor and chromium userdata dirs
 #       if wanted by the user, maybe use env variables
 prepare_docker_userdata_volumes() {
-  [ -n ${CHROME_USERDATA} ] && VOLUMES+=" --volume=${CHROME_USERDATA}:/home/${BROWSER_BOX_USER}/.config/google-chrome"
-  [ -n ${FIREFOX_USERDATA} ] && VOLUMES+=" --volume=${FIREFOX_USERDATA}:/home/${BROWSER_BOX_USER}/.mozilla"
+  [ ! -z ${CHROME_USERDATA} ] && VOLUMES+=" --volume=${CHROME_USERDATA}:/home/${BROWSER_BOX_USER}/.config/google-chrome"
+  [ ! -z ${FIREFOX_USERDATA} ] && VOLUMES+=" --volume=${FIREFOX_USERDATA}:/home/${BROWSER_BOX_USER}/.mozilla"
 }
 
 prepare_docker_device_parameters() {

--- a/scripts/browser-box
+++ b/scripts/browser-box
@@ -1,7 +1,12 @@
 #!/bin/bash
 
 PATH=/usr/sbin:/usr/bin:/sbin:/bin
-
+# TODO: ensure this gets updated by entrypoint script on install
+BROWSER_BOX_USER=${BROWSER_BOX_USER:-browser}
+BROWSER_BOX_REPO=${BROWSER_BOX_REPO:-$USER}
+USER_REPO=${BROWSER_BOX_REPO:-"sameersbn"}
+BROWSERS=(chromium-browser firefox google-chrome google-chrome-stable tor-browser)
+# Persistant data directories CHROME_USERDATA="" FIREFOX_USERDATA=""
 # do we need to use sudo to start docker containers?
 ( id -Gn | grep -q docker ) || SUDO=sudo
 
@@ -27,7 +32,7 @@ cleanup_stopped_browser_box_instances() {
   for c in $(${SUDO} docker ps -a -q)
   do
     image=$(${SUDO} docker inspect -f {{.Config.Image}} ${c})
-    if [[ ${image} == "sameersbn/browser-box:latest" ]]; then
+    if [[ ${image} == "${USER_REPO}/browser-box:latest" ]]; then
       running=$(${SUDO} docker inspect -f {{.State.Running}} ${c})
       if [[ ${running} != true ]]; then
         ${SUDO} docker rm -v "${c}" >/dev/null
@@ -40,6 +45,8 @@ prepare_docker_caps_parameters() {
   case ${1} in
     google-chrome|google-chrome-stable|chromium-browser)
       CAPABILITIES+="--cap-add=SYS_ADMIN"
+      # passing gpu for SANDBOXED support
+      [ -d /dev/dri ] && CAPABILITIES+=" --device /dev/dri"
       ;;
   esac
 }
@@ -50,6 +57,7 @@ prepare_docker_env_parameters() {
   ENV_VARS+=" --env=DISPLAY"
   ENV_VARS+=" --env=XAUTHORITY=${XAUTH}"
   ENV_VARS+=" --env=TZ=$(cat /etc/timezone)"
+  ENV_VARS+=" --env=BROWSER_BOX_USER=${BROWSER_BOX_USER}"
 }
 
 prepare_docker_volume_parameters() {
@@ -59,6 +67,13 @@ prepare_docker_volume_parameters() {
   VOLUMES+=" --volume=${XSOCK}:${XSOCK}"
   VOLUMES+=" --volume=${XAUTH}:${XAUTH}"
   VOLUMES+=" --volume=/run/user/${USER_UID}/pulse:/run/pulse"
+}
+
+# TODO: Need to add tor and chromium userdata dirs
+#       if wanted by the user, maybe use env variables
+prepare_docker_userdata_volumes() {
+  [ -n ${CHROME_USERDATA} ] && VOLUMES+=" --volume=${CHROME_USERDATA}:/home/${BROWSER_BOX_USER}/.config/google-chrome"
+  [ -n ${FIREFOX_USERDATA} ] && VOLUMES+=" --volume=${FIREFOX_USERDATA}:/home/${BROWSER_BOX_USER}/.mozilla"
 }
 
 prepare_docker_device_parameters() {
@@ -72,6 +87,29 @@ prepare_docker_device_parameters() {
   done
 }
 
+browser_exec () {
+  # check state of default $BROWSER
+  browser_state=$(docker inspect --format "{{.State.Running}}" ${BROWSER} 2>/dev/null)
+  if [[ "${browser_state}" == "true" ]]; then
+    ${SUDO} docker exec -i entrypoint.sh ${BROWSER} "$@" 2>/dev/null
+    exit $?
+  else
+    # checke if any other browser's are open to open link
+    for browser in ${BROWSERS[@]}; do
+      browser_state= \
+        $(docker inspect --format "{{.State.Running}}" ${browser} 2>/dev/null)
+      if [[ "${browser_state}" == "true" ]]; then
+        ${SUDO} docker exec -i entrypoint.sh ${browser} "$@" 2>/dev/null
+        exit $?
+      else
+        # no browser is currently running, let's start the default one
+        default_browser=$(which ${BROWSER})
+        exec ${default_browser} $@
+      fi
+    done
+  fi
+}
+
 prog=$(basename $0)
 exec=$(which $prog)
 if [[ ${prog} == "browser-box" ]]; then
@@ -79,6 +117,9 @@ if [[ ${prog} == "browser-box" ]]; then
     google-chrome|google-chrome-stable|tor-browser|chromium-browser|firefox)
       prog=${1}
       shift
+      ;;
+    browser-exec)
+      browser_exec $@
       ;;
     *|help)
       list_browsers
@@ -94,12 +135,15 @@ cleanup_stopped_browser_box_instances
 prepare_docker_caps_parameters $prog
 prepare_docker_env_parameters
 prepare_docker_volume_parameters
+prepare_docker_userdata_volumes
 prepare_docker_device_parameters
 
 echo "Starting ${prog}..."
 ${SUDO} docker run -d \
+  ${BROWSER_BOX_PARMS} \
   ${CAPABILITIES} \
   ${ENV_VARS} \
   ${VIDEO_DEVICES} \
   ${VOLUMES} \
-  sameersbn/browser-box:latest ${prog} $@ >/dev/null
+  --name="${prog}" \
+  ${USER_REPO}/browser-box:latest ${prog} $@ >/dev/null

--- a/scripts/browser-box
+++ b/scripts/browser-box
@@ -3,8 +3,7 @@
 PATH=/usr/sbin:/usr/bin:/sbin:/bin
 # TODO: ensure this gets updated by entrypoint script on install
 BROWSER_BOX_USER=${BROWSER_BOX_USER:-browser}
-BROWSER_BOX_REPO=${BROWSER_BOX_REPO:-$USER}
-USER_REPO=${BROWSER_BOX_REPO:-"sameersbn"}
+BROWSER_BOX_REPO=${BROWSER_BOX_REPO:-sameersbn}
 BROWSERS=(chromium-browser firefox google-chrome google-chrome-stable tor-browser)
 # Persistant data directories CHROME_USERDATA="" FIREFOX_USERDATA=""
 # do we need to use sudo to start docker containers?
@@ -32,7 +31,7 @@ cleanup_stopped_browser_box_instances() {
   for c in $(${SUDO} docker ps -a -q)
   do
     image=$(${SUDO} docker inspect -f {{.Config.Image}} ${c})
-    if [[ ${image} == "${USER_REPO}/browser-box:latest" ]]; then
+    if [[ ${image} == "${BROWSER_BOX_REPO}/browser-box:latest" ]]; then
       running=$(${SUDO} docker inspect -f {{.State.Running}} ${c})
       if [[ ${running} != true ]]; then
         ${SUDO} docker rm -v "${c}" >/dev/null
@@ -58,7 +57,7 @@ prepare_docker_env_parameters() {
   ENV_VARS+=" --env=XAUTHORITY=${XAUTH}"
   ENV_VARS+=" --env=BROWSER_BOX_USER=${BROWSER_BOX_USER}"
   if [ -f /etc/timezone ]; then
-	  ENV_VARS+=" --env=TZ=$(cat /etc/timezone)"
+	ENV_VARS+=" --env=TZ=$(cat /etc/timezone)"
   else
     [ ! -z "${TIMEZONE}" ] && ENV_VARS+=" --env=TZ=${TIMEZONE}"
   fi
@@ -151,4 +150,4 @@ ${SUDO} docker run -d \
   ${VIDEO_DEVICES} \
   ${VOLUMES} \
   --name="${prog}" \
-  ${USER_REPO}/browser-box:latest ${prog} $@ >/dev/null
+  ${BROWSER_BOX_REPO}/browser-box:latest ${prog} $@ >/dev/null


### PR DESCRIPTION
```
* userdata volumes and url opening code were added to use docker-browser as full
    replacement name browser-exec.
* browser-exec allows a user to launch a link in an exisitng browser or
    open up the link in the default browser define by env $BROWSER
* added env variable ${DOCKER_BROWSER_PARMS} allowing user to pass
    aditional parms if he/she so wishes
* added additional userdata volumes so that browser settins persist:
    $CHROME_USERDATA and $FIRFOX_USERDATA
* made it easier for people who fork to test using make file by using env $USER
* added clean function to Makefile
* esnured USERDATA voluems are added to docker run command only withn
    wrapper script
* if userdata volumes are used home directory of browser is created first,
    so added code to ensure home directory has right permissions and
    that /etc/skel files get copied to home directory
* renamed some parms
* tor install binary is now gpg verified and bumped a version closing
    issue#2
* README.md includes information about making the settings for firefox and
    chrome survive after each time the browser is closed and opened.
* nvidia-346 drivers are installed in container in order to fix some glx
    errors.
* if browsers are launched with wrapper script then username within the
    container will be the username of the user executing
* add fonts conf file, fixing font error, file copied from jfrazelle
```
