### PR TITLE
FIX for displays other than :0

### DIFF
--- a/scripts/browser-box
+++ b/scripts/browser-box
@@ -66,7 +66,7 @@ prepare_docker_env_parameters() {
 
 prepare_docker_volume_parameters() {
   touch ${XAUTH}
-  xauth nlist :0 | sed -e 's/^..../ffff/' | xauth -f ${XAUTH} nmerge -
+  xauth nlist ${DISPLAY} | sed -e 's/^..../ffff/' | xauth -f ${XAUTH} nmerge -
 
   VOLUMES+=" --volume=${XSOCK}:${XSOCK}"
   VOLUMES+=" --volume=${XAUTH}:${XAUTH}"


### PR DESCRIPTION
There is on point where `:0` is hard coded. This patch fixes that